### PR TITLE
a few more things

### DIFF
--- a/reddit_thebutton/__init__.py
+++ b/reddit_thebutton/__init__.py
@@ -15,6 +15,9 @@ class TheButton(Plugin):
         ConfigValue.int: [
             "thebutton_srid",
         ],
+        ConfigValue.bool: [
+            "thebutton_is_active",
+        ],
     }
 
     js = {

--- a/reddit_thebutton/__init__.py
+++ b/reddit_thebutton/__init__.py
@@ -9,14 +9,11 @@ class TheButton(Plugin):
         ConfigValue.tuple: [
             "thebutton_caches",
         ],
-        ConfigValue.int: [
-            "thebutton_srid",
-        ],
     }
 
     live_config = {
-        ConfigValue.str: [
-            "thebutton_id",
+        ConfigValue.int: [
+            "thebutton_srid",
         ],
     }
 

--- a/reddit_thebutton/controllers.py
+++ b/reddit_thebutton/controllers.py
@@ -80,8 +80,8 @@ class ButtonApiController(ApiController):
 
         flair_text = "%ss" % seconds_remaining
 
-        setattr(c.user, 'flair_%s_text' % g.thebutton_srid, flair_text)
-        setattr(c.user, 'flair_%s_css_class' % g.thebutton_srid, flair_css)
+        setattr(c.user, 'flair_%s_text' % g.live_config["thebutton_srid"], flair_text)
+        setattr(c.user, 'flair_%s_css_class' % g.live_config["thebutton_srid"], flair_css)
         c.user._commit()
 
 

--- a/reddit_thebutton/controllers.py
+++ b/reddit_thebutton/controllers.py
@@ -34,6 +34,9 @@ class ButtonApiController(ApiController):
         client_seconds_remaining=VInt('seconds', min=0, max=60),
     )
     def POST_press_button(self, client_seconds_remaining):
+        if not g.live_config['thebutton_is_active']:
+            return
+
         if c.user._date > ACCOUNT_CREATION_CUTOFF:
             return
 

--- a/reddit_thebutton/models.py
+++ b/reddit_thebutton/models.py
@@ -68,6 +68,12 @@ def press_button(user):
 
 
 def _update_timer():
+    if not g.live_config['thebutton_is_active']:
+        g.log.debug("%s: thebutton is inactive" % datetime.now(g.tz))
+        websockets.send_broadcast(
+            namespace="/thebutton", type="not_started", payload={})
+        return
+
     expiration_time = has_timer_expired()
     if expiration_time:
         seconds_elapsed = (datetime.now(g.tz) - expiration_time).total_seconds()

--- a/reddit_thebutton/models.py
+++ b/reddit_thebutton/models.py
@@ -21,11 +21,11 @@ ACCOUNT_CREATION_CUTOFF = datetime(2015, 4, 1, 0, 0, tzinfo=g.tz)
 
 
 def _EXPIRED_KEY():
-    return "%s.%s" % (g.live_config["thebutton_id"], TIME_EXPIRED_KEY)
+    return "%s.%s" % (g.live_config["thebutton_srid"], TIME_EXPIRED_KEY)
 
 
 def _CURRENT_PRESS_KEY():
-    return "%s.%s" % (g.live_config["thebutton_id"], CURRENT_PRESS_KEY)
+    return "%s.%s" % (g.live_config["thebutton_srid"], CURRENT_PRESS_KEY)
 
 
 class ButtonPressByUser(tdb_cassandra.View):
@@ -40,7 +40,7 @@ class ButtonPressByUser(tdb_cassandra.View):
 
     @classmethod
     def _rowkey(cls, user):
-        return "%s.%s" % (g.live_config["thebutton_id"], user._id36)
+        return "%s.%s" % (g.live_config["thebutton_srid"], user._id36)
 
     @classmethod
     def pressed(cls, user, dt):
@@ -216,8 +216,8 @@ def _delete_button_flair(user_id36s):
     users = Account._byID36(user_id36s, data=True, return_dict=False)
     for user in users:
         g.log.debug("deleting flair for %s" % user.name)
-        setattr(user, 'flair_%s_text' % g.thebutton_srid, None)
-        setattr(user, 'flair_%s_css_class' % g.thebutton_srid, None)
+        setattr(user, 'flair_%s_text' % g.live_config["thebutton_srid"], None)
+        setattr(user, 'flair_%s_css_class' % g.live_config["thebutton_srid"], None)
         user._commit()
 
 

--- a/reddit_thebutton/models.py
+++ b/reddit_thebutton/models.py
@@ -28,6 +28,9 @@ def _CURRENT_PRESS_KEY():
     return "%s.%s" % (g.live_config["thebutton_srid"], CURRENT_PRESS_KEY)
 
 
+def _PARTICIPANTS_KEY():
+    return "%s.%s" % (g.live_config["thebutton_srid"], PARTICIPANTS_KEY)
+
 class ButtonPressByUser(tdb_cassandra.View):
     _use_db = True
     _connection_pool = 'main'
@@ -195,7 +198,7 @@ def get_current_press():
 
 
 def get_num_participants():
-    return g.thebuttoncache.get(PARTICIPANTS_KEY) or 0
+    return g.thebuttoncache.get(_PARTICIPANTS_KEY()) or 0
 
 
 def set_current_press(press_time):
@@ -203,7 +206,7 @@ def set_current_press(press_time):
     serialized = _serialize_datetime(press_time)
     NamedGlobals.set(key, serialized)
     g.thebuttoncache.set(key, serialized)
-    g.thebuttoncache.incr(PARTICIPANTS_KEY)
+    g.thebuttoncache.incr(_PARTICIPANTS_KEY())
 
 
 def reset_button():
@@ -215,7 +218,7 @@ def reset_button():
     NamedGlobals._cf.remove(press_key)
     g.thebuttoncache.delete(press_key)
 
-    g.thebuttoncache.set(PARTICIPANTS_KEY, 0)
+    g.thebuttoncache.set(_PARTICIPANTS_KEY(), 0)
 
 
 def _delete_button_flair(user_id36s):

--- a/reddit_thebutton/pages.py
+++ b/reddit_thebutton/pages.py
@@ -1,4 +1,4 @@
-from pylons import c
+from pylons import c, g
 
 from r2.lib import websockets
 from r2.lib.pages import Reddit
@@ -20,6 +20,7 @@ class TheButtonBase(Reddit):
 
 class TheButton(Templated):
     def __init__(self):
+        self.is_active = g.live_config['thebutton_is_active']
         self.num_participants = get_num_participants()
         self.has_expired = has_timer_expired()
 


### PR DESCRIPTION
- Move `thebutton_srid` to live config. We shouldn't need to change this but if we do it'll be easier/faster than an ini change.
- Add `thebutton_is_active` to live config. This will make it easier for us to choose when to start thebutton and let us deactivate it if something breaks.
- Fix `PARTICIPANTS_KEY`
- Improve reset functions: make it easier to clear out all data (button presses by user, user flair) or reset the timer (for instance if the site went down and the timer expired, we could reset it without resetting user presses and flair)
## hard reset

Temporarily disable the button to block additional presses and clear out all  data (presses, flair) and reset the timer and participation count.
1. disable thebutton (`g.live_config['thebutton_is_active']`)
2. run `reset_button()`
3. enable thebutton (`g.live_config['thebutton_is_active']`)
## soft reset

Reset the timer if it's expired but keep all existing presses and flair.
1. run `reset_timer()`
## new subreddit

Move thebutton to a new subreddit
1. disable thebutton (`g.live_config['thebutton_is_active']`)
2. modify `g.live_config['thebutton_srid']`
3. run `reset_timer()`
4. enable thebutton (`g.live_config['thebutton_is_active']`)
